### PR TITLE
Optimization: replace format() with f-strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,5 +136,5 @@ cpe (vendor:product)  per version to give a probability of the CPE appearance.
 
 Software is open source and released under a 2-Clause BSD License
 
-Copyright (C) 2021 Alexandre Dulaunoy
-Copyright (C) 2021 Esa Jokinen
+Copyright (C) 2021 Alexandre Dulaunoy  
+Copyright (C) 2021 Esa Jokinen  

--- a/bin/server.py
+++ b/bin/server.py
@@ -7,6 +7,9 @@ import falcon
 from wsgiref.simple_server import make_server
 import json
 
+# Configuration
+port = 8000
+
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 from lib.cpeguesser import CPEGuesser
@@ -36,6 +39,12 @@ if __name__ == '__main__':
     app = falcon.App()
     app.add_route('/search', Search())
 
-    with make_server('', 8000, app) as httpd:
-        print('Serving on port 8000...')
-        httpd.serve_forever()
+    try:
+        with make_server('', port, app) as httpd:
+            print(f"Serving on port {port}...")
+            httpd.serve_forever()
+    except OSError as e:
+        print (e)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/bin/server.py
+++ b/bin/server.py
@@ -5,8 +5,6 @@ import os
 import sys
 import falcon
 from wsgiref.simple_server import make_server
-import requests
-from datetime import datetime
 import json
 
 runPath = os.path.dirname(os.path.realpath(__file__))
@@ -15,7 +13,6 @@ from lib.cpeguesser import CPEGuesser
 
 class Search():
     def on_post(self, req, resp):
-        ret = []
         data_post = req.bounded_stream.read()
         js = data_post.decode('utf-8')
         try:
@@ -23,10 +20,10 @@ class Search():
         except ValueError:
             resp.status = falcon.HTTP_400
             resp.media = "Missing query array or incorrect JSON format"
-            return            
+            return
 
         if 'query' in q:
-            pass 
+            pass
         else:
             resp.status = falcon.HTTP_400
             resp.media = "Missing query array or incorrect JSON format"

--- a/lib/cpeguesser.py
+++ b/lib/cpeguesser.py
@@ -10,7 +10,7 @@ class CPEGuesser():
     def guessCpe(self, words):
         k=[]
         for keyword in words:
-            k.append('w:{}'.format(keyword.lower()))
+            k.append(f"w:{keyword.lower()}")
 
         maxinter = len(k)
         cpes = []


### PR DESCRIPTION
Optimization. Replaces `format()` with f-strings, as it [turned out](https://github.com/cve-search/cpe-guesser/pull/4#issuecomment-924595805) this makes import 15% faster. Also more readable.

I intentionally left the benchmark timer there. May or may not be removed in future.