### PR TITLE
chg: [lookup] use positional arguments for WORD(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,53 +50,55 @@ curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"out
 ### Command line - `lookup.py`
 
 ~~~~
-usage: lookup.py [-h] [--word WORD]
+usage: lookup.py [-h] WORD [WORD ...]
 
 Find potential CPE names from a list of keyword(s) and return a JSON of the results
 
+positional arguments:
+  WORD        One or more keyword(s) to lookup
+
 optional arguments:
-  -h, --help   show this help message and exit
-  --word WORD  One or more keyword(s) to lookup
+  -h, --help  show this help message and exit
 ~~~~
 
 
 ~~~~
-python3 lookup.py  --word microsoft --word sql --word server | jq .
+python3 lookup.py microsoft sql server | jq .
 [
   [
-    51076,
+    51325,
     "cpe:2.3:a:microsoft:sql_server_2017_reporting_services"
   ],
   [
-    51077,
+    51326,
     "cpe:2.3:a:microsoft:sql_server_2019_reporting_services"
   ],
   [
-    57612,
+    57898,
     "cpe:2.3:a:quest:intrust_knowledge_pack_for_microsoft_sql_server"
   ],
   [
-    60090,
+    60386,
     "cpe:2.3:o:microsoft:sql_server"
   ],
   [
-    60660,
+    60961,
     "cpe:2.3:a:microsoft:sql_server_desktop_engine"
   ],
   [
-    64489,
+    64810,
     "cpe:2.3:a:microsoft:sql_server_reporting_services"
   ],
   [
-    75465,
+    75858,
     "cpe:2.3:a:microsoft:sql_server_management_studio"
   ],
   [
-    77161,
+    77570,
     "cpe:2.3:a:microsoft:sql_server"
   ],
   [
-    77793,
+    78206,
     "cpe:2.3:a:ibm:tivoli_storage_manager_for_databases_data_protection_for_microsoft_sql_server"
   ]
 ]

--- a/bin/lookup.py
+++ b/bin/lookup.py
@@ -12,13 +12,8 @@ from lib.cpeguesser import CPEGuesser
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Find potential CPE names from a list of keyword(s) and return a JSON of the results')
-    parser.add_argument('--word', help='One or more keyword(s) to lookup', action='append')
+    parser.add_argument('word', metavar='WORD', type=str, nargs='+', help='One or more keyword(s) to lookup')
     args = parser.parse_args()
-
-    if args.word is None:
-        print("Missing keyword(s)")
-        parser.print_help()
-        sys.exit(1)
 
     cpeGuesser = CPEGuesser()
     print(json.dumps(cpeGuesser.guessCpe(args.word)))


### PR DESCRIPTION
I could have posted this as an issue, but with a pr it's easier to demonstrate this alternative. I'm actually asking to clarify whether there are plans to add any other lookup types than the `--word WORD`? That would make the current syntax a well-founded decision.

Otherwise, for the ease of use, would it be ok to alter the syntax from

```
usage: lookup.py [-h] [--word WORD]

python3 lookup.py  --word microsoft --word sql --word server | jq .
```

to positional arguments:

```
python3 lookup.py microsoft sql server | jq .
```

```
usage: lookup.py [-h] WORD [WORD ...]

Find potential CPE names from a list of keyword(s) and return a JSON of the results

positional arguments:
  WORD        One or more keyword(s) to lookup

optional arguments:
  -h, --help  show this help message and exit
```


Actually, the current help is a bit contradictory, as the `--word` argument seems both mandatory and optional at the same time:

```
Missing keyword(s)
usage: lookup.py [-h] [--word WORD]

Find potential CPE names from a list of keyword(s) and return a JSON of the results

optional arguments:
  -h, --help   show this help message and exit
  --word WORD  One or more keyword(s) to lookup
```

With `nargs='+'` the argparse module internally handles the exception of not giving any arguments, printing the usage:

```
usage: lookup.py [-h] WORD [WORD ...]
lookup.py: error: the following arguments are required: WORD
```

You can merge if you agree, but I wouldn't mind if there were other plans and you'd choose to close this pr. (The documentation is updated accordingly on the same commit.)