### PR TITLE
Add ShellCheck & Black formatting workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,20 @@
+name: Black formatting
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  black:
+    name: Black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Black formatting for Python scripts
+        uses: psf/black@stable
+        with:
+          options: --check --diff --verbose
+          src: .

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,7 +12,7 @@ jobs:
     name: Black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check Black formatting for Python scripts
         uses: psf/black@stable
         with:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -12,7 +12,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck for shell scripts
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,22 @@
+name: ShellCheck
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck for shell scripts
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: style
+          scandir: .
+          format: gcc
+          version: stable

--- a/bin/lookup.py
+++ b/bin/lookup.py
@@ -10,16 +10,16 @@ runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 from lib.cpeguesser import CPEGuesser
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description='Find potential CPE names from a list of keyword(s) and return a JSON of the results'
+        description="Find potential CPE names from a list of keyword(s) and return a JSON of the results"
     )
     parser.add_argument(
-        'word',
-        metavar='WORD',
+        "word",
+        metavar="WORD",
         type=str,
-        nargs='+',
-        help='One or more keyword(s) to lookup',
+        nargs="+",
+        help="One or more keyword(s) to lookup",
     )
     args = parser.parse_args()
 

--- a/bin/server.py
+++ b/bin/server.py
@@ -9,7 +9,7 @@ import json
 from dynaconf import Dynaconf
 
 # Configuration
-settings = Dynaconf(settings_files=['../config/settings.yaml'])
+settings = Dynaconf(settings_files=["../config/settings.yaml"])
 port = settings.server.port
 
 runPath = os.path.dirname(os.path.realpath(__file__))
@@ -20,7 +20,7 @@ from lib.cpeguesser import CPEGuesser
 class Search:
     def on_post(self, req, resp):
         data_post = req.bounded_stream.read()
-        js = data_post.decode('utf-8')
+        js = data_post.decode("utf-8")
         try:
             q = json.loads(js)
         except ValueError:
@@ -28,7 +28,7 @@ class Search:
             resp.media = "Missing query array or incorrect JSON format"
             return
 
-        if 'query' in q:
+        if "query" in q:
             pass
         else:
             resp.status = falcon.HTTP_400
@@ -36,15 +36,15 @@ class Search:
             return
 
         cpeGuesser = CPEGuesser()
-        resp.media = cpeGuesser.guessCpe(q['query'])
+        resp.media = cpeGuesser.guessCpe(q["query"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = falcon.App()
-    app.add_route('/search', Search())
+    app.add_route("/search", Search())
 
     try:
-        with make_server('', port, app) as httpd:
+        with make_server("", port, app) as httpd:
             print(f"Serving on port {port}...")
             httpd.serve_forever()
     except OSError as e:

--- a/lib/cpeguesser.py
+++ b/lib/cpeguesser.py
@@ -5,13 +5,17 @@ import redis
 from dynaconf import Dynaconf
 
 # Configuration
-settings = Dynaconf(
-    settings_files=['../config/settings.yaml']
-)
+settings = Dynaconf(settings_files=["../config/settings.yaml"])
+
 
 class CPEGuesser:
     def __init__(self):
-        self.rdb = redis.Redis(host=settings.redis.host, port=settings.redis.port, db=8, decode_responses=True)
+        self.rdb = redis.Redis(
+            host=settings.redis.host,
+            port=settings.redis.port,
+            db=8,
+            decode_responses=True,
+        )
 
     def guessCpe(self, words):
         k = []
@@ -28,7 +32,7 @@ class CPEGuesser:
         ranked = []
 
         for cpe in result:
-            rank = self.rdb.zrank('rank:cpe', cpe)
+            rank = self.rdb.zrank("rank:cpe", cpe)
             ranked.append((rank, cpe))
 
         return sorted(ranked)


### PR DESCRIPTION
- Add linter workflows:
  - Black formatting workflow that is already in use for cve-search & CveXplore.
  - ShellCheck workflow as there is at least one shell script in this repository.
- Apply Black 24.3.0 formatting for these checks to pass.