### PR TITLE
fix: [docker] use valkey in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 8000:8000
     depends_on:
-      - redis
-  redis:
+      - valkey
+  valkey:
     container_name: cpe-guesser-db
-    image: "redis:alpine"
+    image: "valkey/valkey:alpine"

--- a/docker/settings.yaml
+++ b/docker/settings.yaml
@@ -1,7 +1,7 @@
 server:
   port: 8000
-redis:
-  host: redis
+valkey:
+  host: valkey
   port: 6379
 cpe:
   path: '/data/official-cpe-dictionary_v2.3.xml'


### PR DESCRIPTION
Changes:

- Use Valkey in `docker-compose` to maintain compatibility with the repo
- Fix the default `settings.yaml` for docker-compose