### PR TITLE
Improve configuration robustness and fix Docker deployment

### DIFF
--- a/bin/import.py
+++ b/bin/import.py
@@ -14,11 +14,16 @@ from dynaconf import Dynaconf
 
 # Configuration
 settings = Dynaconf(settings_files=["../config/settings.yaml"])
-cpe_path = settings.cpe.path
-cpe_source = settings.cpe.source
-rdb = valkey.Valkey(
-    host=settings.valkey.host, port=settings.valkey.port, db=settings.valkey.db
+cpe_path = settings.get("cpe.path", "../data/official-cpe-dictionary_v2.3.xml")
+cpe_source = settings.get(
+    "cpe.source",
+    "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz",
 )
+valkey_host = settings.get("valkey.host", "127.0.0.1")
+valkey_port = settings.get("valkey.port", 6379)
+valkey_db = settings.get("valkey.db", 8)
+
+rdb = valkey.Valkey(host=valkey_host, port=valkey_port, db=valkey_db)
 
 
 class CPEHandler(xml.sax.ContentHandler):

--- a/bin/import.py
+++ b/bin/import.py
@@ -16,7 +16,9 @@ from dynaconf import Dynaconf
 settings = Dynaconf(settings_files=["../config/settings.yaml"])
 cpe_path = settings.cpe.path
 cpe_source = settings.cpe.source
-rdb = valkey.Valkey(host=settings.valkey.host, port=settings.valkey.port, db=8)
+rdb = valkey.Valkey(
+    host=settings.valkey.host, port=settings.valkey.port, db=settings.valkey.db
+)
 
 
 class CPEHandler(xml.sax.ContentHandler):

--- a/bin/server.py
+++ b/bin/server.py
@@ -10,7 +10,7 @@ from dynaconf import Dynaconf
 
 # Configuration
 settings = Dynaconf(settings_files=["../config/settings.yaml"])
-port = settings.server.port
+port = settings.get("server.port", 8000)
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -3,6 +3,7 @@ server:
 valkey:
   host: 127.0.0.1
   port: 6379
+  db: 8
 cpe:
   path: '../data/official-cpe-dictionary_v2.3.xml'
   source: 'https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz'

--- a/docker/settings.yaml
+++ b/docker/settings.yaml
@@ -3,6 +3,7 @@ server:
 valkey:
   host: valkey
   port: 6379
+  db: 8
 cpe:
   path: '/data/official-cpe-dictionary_v2.3.xml'
   source: 'https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz'

--- a/docker/settings.yaml
+++ b/docker/settings.yaml
@@ -1,6 +1,6 @@
 server:
   port: 8000
-redis:
+valkey:
   host: valkey
   port: 6379
 cpe:

--- a/lib/cpeguesser.py
+++ b/lib/cpeguesser.py
@@ -6,14 +6,17 @@ from dynaconf import Dynaconf
 
 # Configuration
 settings = Dynaconf(settings_files=["../config/settings.yaml"])
+valkey_host = settings.get("valkey.host", "127.0.0.1")
+valkey_port = settings.get("valkey.port", 6379)
+valkey_db = settings.get("valkey.db", 8)
 
 
 class CPEGuesser:
     def __init__(self):
         self.rdb = valkey.Valkey(
-            host=settings.valkey.host,
-            port=settings.valkey.port,
-            db=settings.valkey.db,
+            host=valkey_host,
+            port=valkey_port,
+            db=valkey_db,
             decode_responses=True,
         )
 

--- a/lib/cpeguesser.py
+++ b/lib/cpeguesser.py
@@ -13,7 +13,7 @@ class CPEGuesser:
         self.rdb = valkey.Valkey(
             host=settings.valkey.host,
             port=settings.valkey.port,
-            db=8,
+            db=settings.valkey.db,
             decode_responses=True,
         )
 


### PR DESCRIPTION
This PR fixes a configuration key mismatch in the Docker setup, makes the Valkey database number configurable, and embeds the documented defaults directly into the code. These changes ensure the application runs reliably even when configuration files are missing or incomplete.

Fixes https://github.com/cve-search/cpe-guesser/issues/16