### PR TITLE
Normalize CPE guessing/indexing for dashed and underscored names

### DIFF
--- a/lib/cpeguesser.py
+++ b/lib/cpeguesser.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import valkey
+import re
 from dynaconf import Dynaconf
 
 # Configuration
@@ -28,9 +29,17 @@ class CPEGuesser:
         score = self.rdb.zscore("rank:cpe", cpe)
         return score or 0
 
+    def _normalize_keywords(self, words):
+        normalized = []
+        for word in words:
+            parts = [part for part in re.split(r"[\s_-]+", word.lower()) if part]
+            normalized.extend(parts)
+        return normalized
+
     def guessCpe(self, words):
         k = []
-        for keyword in words:
+        normalized_words = self._normalize_keywords(words)
+        for keyword in normalized_words:
             k.append(f"w:{keyword.lower()}")
 
         if not k:
@@ -41,7 +50,7 @@ class CPEGuesser:
             return []
 
         ranked = []
-        lowered_words = [word.lower() for word in words]
+        lowered_words = normalized_words
 
         for cpe in result:
             search_score = sum(self._word_score(word, cpe) for word in lowered_words)

--- a/lib/cpeimport/base.py
+++ b/lib/cpeimport/base.py
@@ -1,4 +1,5 @@
 import time
+import re
 from abc import ABC, abstractmethod
 
 
@@ -56,7 +57,7 @@ class CPEImportHandler(ABC):
         return {"vendor": vendor, "product": product, "cpeline": cpeline}
 
     def canonize(self, value):
-        return value.lower().split("_")
+        return [part for part in re.split(r"[\s_-]+", value.lower()) if part]
 
     def insert(self, word, cpe):
         self.rdb.sadd(f"w:{word}", cpe)

--- a/tests/test_cpeguesser.py
+++ b/tests/test_cpeguesser.py
@@ -83,6 +83,20 @@ class CPEGuesserTestCase(unittest.TestCase):
             ],
         )
 
+    def test_guess_cpe_normalizes_dashes_underscores_and_spaces(self):
+        rdb = FakeRDB()
+        launcher = "cpe:2.3:a:acme:rocket_launcher"
+
+        for key in ("w:acme", "w:rocket", "w:launcher"):
+            rdb.sadd(key, launcher)
+            rdb.zadd(f"s:{key[2:]}", {launcher: 1})
+
+        guesser = CPEGuesser(rdb=rdb)
+
+        self.assertEqual(guesser.guessCpe(["acme", "rocket-launcher"]), [(3, launcher)])
+        self.assertEqual(guesser.guessCpe(["acme", "rocket_launcher"]), [(3, launcher)])
+        self.assertEqual(guesser.guessCpe(["acme", "rocket launcher"]), [(3, launcher)])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nvd_json.py
+++ b/tests/test_nvd_json.py
@@ -103,6 +103,32 @@ class NVDCPEHandlerTestCase(unittest.TestCase):
         self.assertEqual(serial_rdb.sets, parallel_rdb.sets)
         self.assertEqual(serial_rdb.sorted_sets, parallel_rdb.sorted_sets)
 
+    def test_import_splits_hyphenated_vendor_and_product_words(self):
+        rdb = FakeRDB()
+        handler = NVDCPEHandler(rdb, workers=1, batch_size=10)
+        payload = io.StringIO(
+            json.dumps(
+                {
+                    "products": [
+                        {
+                            "cpe": {
+                                "cpeName": (
+                                    "cpe:2.3:a:foo-bar:rocket-launcher:1.0:*:*:*:*:*:*:*"
+                                )
+                            }
+                        }
+                    ]
+                }
+            )
+        )
+
+        handler.process_json_file(payload)
+
+        self.assertEqual(rdb.sets["w:foo"], {"cpe:2.3:a:foo-bar:rocket-launcher"})
+        self.assertEqual(rdb.sets["w:bar"], {"cpe:2.3:a:foo-bar:rocket-launcher"})
+        self.assertEqual(rdb.sets["w:rocket"], {"cpe:2.3:a:foo-bar:rocket-launcher"})
+        self.assertEqual(rdb.sets["w:launcher"], {"cpe:2.3:a:foo-bar:rocket-launcher"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Hyphenated, underscored, or space-separated vendor/product names were not consistently tokenized, causing lookups like `rocket-launcher`, `rocket_launcher`, and `rocket launcher` to miss matches. 
- The importer and guesser must use the same tokenization rules so indexing and searching behave consistently for names with `-`, `_`, or spaces.

### Description
- Add `_normalize_keywords` to `CPEGuesser` which lowercases and splits input keywords on spaces, underscores, and dashes using `re.split(r"[\s_-]+", ...)`, and use the normalized tokens for set intersection and scoring. 
- Change `canonize` in `lib/cpeimport/base.py` to split vendor/product strings with the same `re.split(r"[\s_-]+", ...)` rule so hyphenated names are indexed as component words. 
- Add regression tests in `tests/test_cpeguesser.py` to verify guessing works for `rocket-launcher`, `rocket_launcher`, and `rocket launcher`. 
- Add importer test coverage in `tests/test_nvd_json.py` to verify hyphenated vendor/product values are split and indexed into component words.

### Testing
- Ran unit subsets with `PYTHONPATH=. pytest -q tests/test_cpeguesser.py tests/test_nvd_json.py` and the tests passed (both files green). 
- Ran full test suite with `PYTHONPATH=. pytest -q` and observed all tests passing (`12 passed`). 
- A plain `pytest -q` run without `PYTHONPATH=.` failed to import the `lib` package in this environment, so test runs shown above use the correct `PYTHONPATH` to validate changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca63e43d9c83249f5fd1b18d33bf42)